### PR TITLE
Removing --show-lables from global flags

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,9 +42,6 @@ var _ = commander.RegisterCommandInit(func() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/"+pxDefaultDir+"/"+pxDefaultConfigName+")")
 	rootCmd.PersistentFlags().StringVar(&cfgContext, "context", "", "Force context name for the command")
 
-	// TODO: move these flags out of persistent
-	rootCmd.PersistentFlags().Bool("show-labels", false, "Show labels in the last column of the output")
-
 	// Global cobra configurations
 	rootCmd.Flags().SortFlags = false
 })


### PR DESCRIPTION
Removed --show-labels from the global flag

Before fix output
```
Prashanths-MacBook-Pro:pxc prashanthkumar$ ./pxc get volume --help
Get information about Portworx volumes

Usage:
  px get volume [flags]

Aliases:
  volume, volumes

Flags:
      --deep                 Collect more information, this may delay the request
  -h, --help                 help for volume
  -o, --output string        Output in yaml|json|wide
      --owner string         Owner of volume
  -l, --selector string      Selector (label query) comma-separated name=value pairs
      --show-k8s-info        Show kubernetes information
      --volumegroup string   Volume group id

Global Flags:
      --config string    config file (default is $HOME/.px/config.yml)
      --context string   Force context name for the command
      --show-labels      Show labels in the last column of the output

```

After fix
```
Prashanths-MacBook-Pro:pxc prashanthkumar$ ./pxc get volume --help
Get information about Portworx volumes

Usage:
  px get volume [flags]

Aliases:
  volume, volumes

Flags:
      --deep                 Collect more information, this may delay the request
  -h, --help                 help for volume
  -o, --output string        Output in yaml|json|wide
      --owner string         Owner of volume
  -l, --selector string      Selector (label query) comma-separated name=value pairs
      --show-k8s-info        Show kubernetes information
      --show-labels          Show labels in the last column of the output
      --volumegroup string   Volume group id

Global Flags:
      --config string    config file (default is $HOME/.px/config.yml)
      --context string   Force context name for the command
```