### PR TITLE
Added update, remove of volume access support in patch command.

### DIFF
--- a/handler/test/common.go
+++ b/handler/test/common.go
@@ -98,7 +98,7 @@ func ExecuteCli(cli string) ([]string, []string, error) {
 // Takes a volume name and size. Returns the created volume id.
 // For some reason our test container only recoganizes id and not name for some calls.
 func PxTestCreateVolume(t *testing.T, volName string, size uint64) {
-	cli := fmt.Sprintf("px create volume %s --size %s --groups group1:r --collaborators user1:w", volName, strconv.FormatUint(size, 10))
+	cli := fmt.Sprintf("pxc create volume %s --size %s --groups group1:r --collaborators user1:w", volName, strconv.FormatUint(size, 10))
 	lines, _, err := ExecuteCli(cli)
 	assert.NoError(t, err)
 
@@ -107,7 +107,7 @@ func PxTestCreateVolume(t *testing.T, volName string, size uint64) {
 
 // Takes a volume name and size. Returns the created volume id.
 func PxTestCreateVolumeWithLabel(t *testing.T, volName string, size uint64, labels string) {
-	cli := fmt.Sprintf("px create volume %s --size %s --labels %s",
+	cli := fmt.Sprintf("pxc create volume %s --size %s --labels %s",
 		volName, strconv.FormatUint(size, 10), labels)
 	lines, _, err := ExecuteCli(cli)
 	assert.NoError(t, err)
@@ -118,30 +118,30 @@ func PxTestCreateVolumeWithLabel(t *testing.T, volName string, size uint64, labe
 // Takes a volume id assert volume exists
 func PxTestHasVolume(id string) bool {
 	// Get volume information
-	cli := "px get volume " + id
+	cli := "pxc get volume " + id
 	_, _, err := ExecuteCli(cli)
 
 	return err == nil
 }
 
 func PxTestGetVolumeWithLabels(t *testing.T, selector string) (*bytes.Buffer, error) {
-	cli := fmt.Sprintf("px get volume --show-labels --selector %s", selector)
+	cli := fmt.Sprintf("pxc get volume --show-labels --selector %s", selector)
 	so, _, err := executeCliRaw(cli)
 	return so, err
 }
 
 func PxTestGetVolumeWithNameSelector(t *testing.T, volName string, selector string) {
-	cli := fmt.Sprintf("px get volume %s --show-labels --selector %s", volName, selector)
+	cli := fmt.Sprintf("pxc get volume %s --show-labels --selector %s", volName, selector)
 	_, _, err := executeCliRaw(cli)
 	assert.Error(t, err)
 }
 
 // Return volume information
-// TODO: If necessary, we can do a `px get volume <id> -o json` then
+// TODO: If necessary, we can do a `pxc get volume <id> -o json` then
 //       unmarshal the JSON to appropriate object
 // 		 then return the &api.Volume inside of it.
 func PxTestVolumeInfo(t *testing.T, id string) *api.Volume {
-	cli := fmt.Sprintf("px get volume %s -o json", id)
+	cli := fmt.Sprintf("pxc get volume %s -o json", id)
 	so, _, err := executeCliRaw(cli)
 	assert.NoError(t, err)
 
@@ -159,7 +159,7 @@ func PxTestVolumeInfo(t *testing.T, id string) *api.Volume {
 //       parse, and as a library function, it may be easier to
 //       get a specific volume.
 func PxTestGetAllVolumes(t *testing.T) []string {
-	cli := fmt.Sprintf("px get volume")
+	cli := fmt.Sprintf("pxc get volume")
 	lines, _, err := ExecuteCli(cli)
 	assert.NoError(t, err)
 
@@ -177,14 +177,14 @@ func PxTestGetAllVolumes(t *testing.T) []string {
 
 // Deletes specified volume
 func PxTestDeleteVolume(t *testing.T, volName string) {
-	cli := fmt.Sprintf("px delete volume %s", volName)
+	cli := fmt.Sprintf("pxc delete volume %s", volName)
 	_, _, err := ExecuteCli(cli)
 	assert.NoError(t, err)
 }
 
 // Takes a volume name and snapshot name
 func PxTestCreateSnapshot(t *testing.T, volId string, snapName string) {
-	cli := fmt.Sprintf("px create volumesnapshot %s %s", volId, snapName)
+	cli := fmt.Sprintf("pxc create volumesnapshot %s %s", volId, snapName)
 	lines, _, err := ExecuteCli(cli)
 	assert.NoError(t, err)
 
@@ -193,7 +193,7 @@ func PxTestCreateSnapshot(t *testing.T, volId string, snapName string) {
 
 // Takes a volume name and clone name
 func PxTestCreateClone(t *testing.T, volId string, cloneName string) {
-	cli := fmt.Sprintf("px create volumeclone %s %s", volId, cloneName)
+	cli := fmt.Sprintf("pxc create volumeclone %s %s", volId, cloneName)
 	lines, _, err := ExecuteCli(cli)
 	assert.NoError(t, err)
 
@@ -202,7 +202,7 @@ func PxTestCreateClone(t *testing.T, volId string, cloneName string) {
 
 // Helper function to create volume with "sticky" flag set
 func PxTestCreateStickyVolume(t *testing.T, volName string, size uint64) {
-	cli := fmt.Sprintf("px create volume %s --size %d --sticky",
+	cli := fmt.Sprintf("pxc create volume %s --size %d --sticky",
 		volName, size)
 	lines, _, err := ExecuteCli(cli)
 	assert.NoError(t, err)
@@ -212,7 +212,7 @@ func PxTestCreateStickyVolume(t *testing.T, volName string, size uint64) {
 
 // Helper function to create volume with "encryption" flag set
 func PxTestCreateEncrypVolume(t *testing.T, volName string, size uint64) {
-	cli := fmt.Sprintf("px create volume %s --size %d --encryption",
+	cli := fmt.Sprintf("pxc create volume %s --size %d --encryption",
 		volName, size)
 	lines, _, err := ExecuteCli(cli)
 	assert.NoError(t, err)
@@ -222,7 +222,7 @@ func PxTestCreateEncrypVolume(t *testing.T, volName string, size uint64) {
 
 // Helper function to create volume with "journal" flag set
 func PxTestCreateJournalVolume(t *testing.T, volName string, size uint64) {
-	cli := fmt.Sprintf("px create volume %s --size %d --journal",
+	cli := fmt.Sprintf("pxc create volume %s --size %d --journal",
 		volName, size)
 	lines, _, err := ExecuteCli(cli)
 	assert.NoError(t, err)
@@ -232,7 +232,7 @@ func PxTestCreateJournalVolume(t *testing.T, volName string, size uint64) {
 
 // Helper function to create volume with access (--groups and --collaborators) flag set
 func PxTestCreateVolumeWithAccess(t *testing.T, volName string, size uint64, groups string, collaborators string) {
-	cli := fmt.Sprintf("px create volume %s --size %d --groups %s --collaborators %s",
+	cli := fmt.Sprintf("pxc create volume %s --size %d --groups %s --collaborators %s",
 		volName, size, groups, collaborators)
 	lines, _, err := ExecuteCli(cli)
 	assert.NoError(t, err)
@@ -242,7 +242,7 @@ func PxTestCreateVolumeWithAccess(t *testing.T, volName string, size uint64, gro
 
 // Helper function to create volume with "aggregation level" flag set
 func PxTestCreateAggrVolume(t *testing.T, volName string, size uint64, aggrLevel uint32) {
-	cli := fmt.Sprintf("px create volume %s --size %d --aggregation-level %d",
+	cli := fmt.Sprintf("pxc create volume %s --size %d --aggregation-level %d",
 		volName, size, aggrLevel)
 	lines, _, err := ExecuteCli(cli)
 	assert.NoError(t, err)
@@ -252,7 +252,7 @@ func PxTestCreateAggrVolume(t *testing.T, volName string, size uint64, aggrLevel
 
 // Helper function to create volume with "io profile" flag set
 func PxTestCreateIoProfVolume(t *testing.T, volName string, size uint64, IoProfile string) {
-	cli := fmt.Sprintf("px create volume %s --size %d --ioprofile %s",
+	cli := fmt.Sprintf("pxc create volume %s --size %d --ioprofile %s",
 		volName, size, IoProfile)
 	lines, _, err := ExecuteCli(cli)
 	assert.NoError(t, err)
@@ -261,25 +261,61 @@ func PxTestCreateIoProfVolume(t *testing.T, volName string, size uint64, IoProfi
 }
 
 func PxTestPatchVolumeHalevel(t *testing.T, volName string, haLevel int) {
-	cli := fmt.Sprintf("px patch volume %s --halevel %d", volName, haLevel)
+	cli := fmt.Sprintf("pxc patch volume %s --halevel %d", volName, haLevel)
 	lines, _, _ := ExecuteCli(cli)
 	assert.Equal(t, "Volume "+volName+" parameter updated successfully", lines[0])
 }
 
 func PxTestPatchVolumeHalevelWithNodes(t *testing.T, volName string, haLevel int64, node string) {
-	cli := fmt.Sprintf("px patch volume %s --halevel %d --node %s", volName, haLevel, node)
+	cli := fmt.Sprintf("pxc patch volume %s --halevel %d --node %s", volName, haLevel, node)
 	lines, _, _ := ExecuteCli(cli)
 	assert.Equal(t, "Volume "+volName+" parameter updated successfully", lines)
 }
 
 func PxTestPatchVolumeResize(t *testing.T, volName string, size uint64) {
-	cli := fmt.Sprintf("px patch volume %s --size %d", volName, size)
+	cli := fmt.Sprintf("pxc patch volume %s --size %d", volName, size)
 	lines, _, _ := ExecuteCli(cli)
 	assert.Equal(t, "Volume "+volName+" parameter updated successfully", lines[0])
 }
 
 func PxTestPatchVolumeShared(t *testing.T, volName string, shared string) {
-	cli := fmt.Sprintf("px patch volume %s --shared %s", volName, shared)
+	cli := fmt.Sprintf("pxc patch volume %s --shared %s", volName, shared)
+	lines, _, _ := ExecuteCli(cli)
+	assert.Equal(t, "Volume "+volName+" parameter updated successfully", lines[0])
+}
+
+func PxTestPatchVolumeAddCollaborators(t *testing.T, volName string, collaborators string) {
+	cli := fmt.Sprintf("pxc patch volume %s  --add-collaborators %s", volName, collaborators)
+	lines, _, _ := ExecuteCli(cli)
+	assert.Equal(t, "Volume "+volName+" parameter updated successfully", lines[0])
+}
+
+func PxTestPatchVolumeRemoveCollaborators(t *testing.T, volName string, collaborators string) {
+	cli := fmt.Sprintf("pxc patch volume %s  --remove-collaborators %s", volName, collaborators)
+	lines, _, _ := ExecuteCli(cli)
+	assert.Equal(t, "Volume "+volName+" parameter updated successfully", lines[0])
+}
+
+func PxTestPatchVolumeRemoveAllCollaborators(t *testing.T, volName string) {
+	cli := fmt.Sprintf("pxc patch volume %s  --remove-all-collaborators=true", volName)
+	lines, _, _ := ExecuteCli(cli)
+	assert.Equal(t, "Volume "+volName+" parameter updated successfully", lines[0])
+}
+
+func PxTestPatchVolumeAddGroups(t *testing.T, volName string, groups string) {
+	cli := fmt.Sprintf("px patch volume %s  --add-groups %s", volName, groups)
+	lines, _, _ := ExecuteCli(cli)
+	assert.Equal(t, "Volume "+volName+" parameter updated successfully", lines[0])
+}
+
+func PxTestPatchVolumeRemoveGroups(t *testing.T, volName string, groups string) {
+	cli := fmt.Sprintf("px patch volume %s  --remove-groups %s", volName, groups)
+	lines, _, _ := ExecuteCli(cli)
+	assert.Equal(t, "Volume "+volName+" parameter updated successfully", lines[0])
+}
+
+func PxTestPatchVolumeRemoveAllGroups(t *testing.T, volName string) {
+	cli := fmt.Sprintf("px patch volume %s  --remove-all-groups=true", volName)
 	lines, _, _ := ExecuteCli(cli)
 	assert.Equal(t, "Volume "+volName+" parameter updated successfully", lines[0])
 }

--- a/handler/volume/create.go
+++ b/handler/volume/create.go
@@ -119,9 +119,10 @@ func createVolumeExec(c *cobra.Command, args []string) error {
 		}
 	}
 
-	cvOpts.req.Spec.Ownership = &api.Ownership{}
-	cvOpts.req.Spec.Ownership.Acls = &api.Ownership_AccessControl{}
-
+	if len(cvOpts.collaborators) != 0 || len(cvOpts.groups) != 0 {
+		cvOpts.req.Spec.Ownership = &api.Ownership{}
+		cvOpts.req.Spec.Ownership.Acls = &api.Ownership_AccessControl{}
+	}
 	// Get collaborators
 	if len(cvOpts.collaborators) != 0 {
 		collaborators, err := util.GetAclMapFromString(cvOpts.collaborators)

--- a/handler/volume/patch.go
+++ b/handler/volume/patch.go
@@ -20,19 +20,33 @@ import (
 
 	api "github.com/libopenstorage/openstorage-sdk-clients/sdk/golang"
 	"github.com/portworx/pxc/cmd"
+	"github.com/portworx/pxc/pkg/cliops"
 	"github.com/portworx/pxc/pkg/commander"
-	"github.com/portworx/pxc/pkg/portworx"
 	"github.com/portworx/pxc/pkg/util"
 	"github.com/spf13/cobra"
 )
 
 type volumeUpdateOpts struct {
-	req        *api.SdkVolumeUpdateRequest
-	halevel    int64
-	replicaSet []string
-	size       uint64
-	shared     string
-	sticky     string
+	req                    *api.SdkVolumeUpdateRequest
+	halevel                int64
+	replicaSet             []string
+	size                   uint64
+	shared                 string
+	sticky                 string
+	addCollaborators       string
+	addGroups              string
+	removeCollaborators    string
+	removeGroups           string
+	removeAllCollaborators bool
+	removeAllGroups        bool
+}
+
+// Struct that contains flag to track the options that set in the current context.
+// This struct variables will be used to check the invalid combination of the flag options.
+type volumeUpdateOptionStatus struct {
+	haLevelSet, sizeSet, sharedSet, stickySet                              bool
+	addGroupsSet, removeGroupsSet, removeAllGroupsSet                      bool
+	addCollaboratorsSet, removeCollaboratorsSet, removeAllCollaboratorsSet bool
 }
 
 var (
@@ -79,25 +93,171 @@ var _ = commander.RegisterCommandInit(func() {
 	patchVolumeCmd.Flags().Uint64VarP(&updateReq.size, "size", "s", 0, "New size for the volume (GiB) (default 1)")
 	patchVolumeCmd.Flags().StringVarP(&updateReq.shared, "shared", "r", "", "set shared setting (Valid Values: [on off]) (default \"off\")")
 	patchVolumeCmd.Flags().StringVarP(&updateReq.sticky, "sticky", "t", "", "set sticky setting (Valid Values: [on off]) (default \"off\")")
+	patchVolumeCmd.Flags().StringVar(&updateReq.addCollaborators, "add-collaborators", "", "Add list of collaborators to the existing list")
+	patchVolumeCmd.Flags().StringVar(&updateReq.addGroups, "add-groups", "", "Add list of groups to the existing list")
+	patchVolumeCmd.Flags().StringVar(&updateReq.removeCollaborators, "remove-collaborators", "", "Remove the given users from the collaborators list")
+	patchVolumeCmd.Flags().StringVar(&updateReq.removeGroups, "remove-groups", "", "Remove the given groups from the group list")
+	patchVolumeCmd.Flags().BoolVarP(&updateReq.removeAllCollaborators, "remove-all-collaborators", "", false, "Remove all the user from the collaborators list")
+	patchVolumeCmd.Flags().BoolVarP(&updateReq.removeAllGroups, "remove-all-groups", "", false, "Remove all the groups from the group list")
 	patchVolumeCmd.Flags().SortFlags = false
 })
+
+// validateVolumeUpdateOptions will check for the valid combination of the flag option.
+func validateVolumeUpdateOptions(status volumeUpdateOptionStatus) error {
+	if status.haLevelSet {
+		if status.sizeSet || status.sharedSet || status.stickySet {
+			return fmt.Errorf("Error: --halevel is not a valid combination with --size or --shared or --sticky")
+		}
+	}
+	if status.removeAllCollaboratorsSet {
+		if status.addCollaboratorsSet || status.removeCollaboratorsSet {
+			return fmt.Errorf("Error: remove-all-collaborators is not a valid combination with --add-collaborators or --remove-collaborators")
+		}
+	}
+	if status.removeAllGroupsSet {
+		if status.addGroupsSet || status.removeGroupsSet {
+			return fmt.Errorf("Error: remove-all-groups is not a valid combination with --add-groups or --remove-groups")
+
+		}
+	}
+	return nil
+}
 
 func PatchAddCommand(cmd *cobra.Command) {
 	patchVolumeCmd.AddCommand(cmd)
 }
 
 func updateVolume(cmd *cobra.Command, args []string) error {
-	ctx, conn, err := portworx.PxConnectDefault()
-	if err != nil {
-		return err
-	}
-	// To track if any value of updateReq is set.
-	updateReqSet := false
 
-	defer conn.Close()
+	var volumeFlagStatus volumeUpdateOptionStatus
+
+	// Parse out all of the common cli volume flags
+	cvi := cliops.GetCliVolumeInputs(cmd, args)
+	// Create a CliVolumeOps object
+	cvOps := cliops.NewCliVolumeOps(cvi)
+	// Connect to px and k8s (if needed)
+	err := cvOps.Connect()
+
+	defer cvOps.Close()
+
 	// fetch the volume name from args
 	updateReq.req.VolumeId = args[0]
+
 	updateReq.req.Spec = &api.VolumeSpecUpdate{}
+
+	if len(updateReq.addCollaborators) != 0 || len(updateReq.addGroups) != 0 ||
+		!updateReq.removeAllCollaborators || !updateReq.removeAllGroups ||
+		len(updateReq.removeCollaborators) != 0 || len(updateReq.removeGroups) != 0 {
+		// For removeAllCollaborators and removeAllGroups, Initialize a empty Ownership
+		// For addCollaborators, addGroups, removeCollaborators and removeGroups,
+		// Intialize a empty Ownership and update the values later.
+		updateReq.req.Spec.Ownership = &api.Ownership{}
+		updateReq.req.Spec.Ownership.Acls = &api.Ownership_AccessControl{}
+	}
+
+	var currentGroups map[string]api.Ownership_AccessType
+	var currentCollaborators map[string]api.Ownership_AccessType
+
+	if len(updateReq.addCollaborators) != 0 || len(updateReq.addGroups) != 0 ||
+		len(updateReq.removeCollaborators) != 0 || len(updateReq.removeGroups) != 0 {
+		cvOps.PxVolumeOps.GetPxVolumeOpsInfo().VolNames = make([]string, 1, 1)
+		// Assign the user given volume Name
+		cvOps.PxVolumeOps.GetPxVolumeOpsInfo().VolNames[0] = updateReq.req.VolumeId
+
+		// Get the current copy of the volume spec
+		vols, err := cvOps.PxVolumeOps.GetVolumes()
+		if err != nil {
+			return err
+		}
+		if len(vols) == 0 {
+			return fmt.Errorf("Error: Volume: %s not found\n", updateReq.req.VolumeId)
+		}
+		v := vols[0].GetVolume()
+		spec := v.GetSpec()
+
+		// Read the current collaborators
+		currentCollaborators = spec.GetOwnership().GetAcls().GetCollaborators()
+		// Read the current Groups
+		currentGroups = spec.GetOwnership().GetAcls().GetGroups()
+	}
+
+	// Update the  collaborators list
+	if len(updateReq.addCollaborators) != 0 {
+		newCollaborators, err := util.GetAclMapFromString(updateReq.addCollaborators)
+		if err != nil {
+			return err
+		}
+		if currentCollaborators == nil {
+			// If the currentCollaborators list is empty, directly assign the new set of collaborators
+			currentCollaborators = newCollaborators
+		} else {
+			// If the currentCollaborators list is not empty, merge the new collaborators list to the current collaborators list.
+			for key, value := range newCollaborators {
+				currentCollaborators[key] = value
+			}
+		}
+		updateReq.req.Spec.Ownership.Acls.Collaborators = currentCollaborators
+		updateReq.req.Spec.Ownership.Acls.Groups = currentGroups
+		volumeFlagStatus.addCollaboratorsSet = true
+	}
+
+	// Update the  groups list
+	if len(updateReq.addGroups) != 0 {
+		newGroups, err := util.GetAclMapFromString(updateReq.addGroups)
+		if err != nil {
+			return err
+		}
+		if currentGroups == nil {
+			// If the currentGroups list is empty, directly assign the new set of Groups
+			currentGroups = newGroups
+		} else {
+			// If the currentGroups list is not empty, merge the new Groups list to the current Groups list.
+			for key, value := range newGroups {
+				currentGroups[key] = value
+			}
+		}
+		updateReq.req.Spec.Ownership.Acls.Groups = currentGroups
+		updateReq.req.Spec.Ownership.Acls.Collaborators = currentCollaborators
+		volumeFlagStatus.addGroupsSet = true
+	}
+
+	// Remove the given list of collaborators
+	if len(updateReq.removeCollaborators) != 0 {
+		removeCollaborators, err := util.GetAclMapFromString(updateReq.removeCollaborators)
+		if err != nil {
+			return nil
+		}
+		for key, _ := range removeCollaborators {
+			delete(currentCollaborators, key)
+		}
+		updateReq.req.Spec.Ownership.Acls.Collaborators = currentCollaborators
+		updateReq.req.Spec.Ownership.Acls.Groups = currentGroups
+		volumeFlagStatus.removeCollaboratorsSet = true
+	}
+
+	// Remove the given list of Groups
+	if len(updateReq.removeGroups) != 0 {
+		removeGroups, err := util.GetAclMapFromString(updateReq.removeGroups)
+		if err != nil {
+			return nil
+		}
+		for key, _ := range removeGroups {
+			delete(currentGroups, key)
+		}
+		updateReq.req.Spec.Ownership.Acls.Groups = currentGroups
+		updateReq.req.Spec.Ownership.Acls.Collaborators = currentCollaborators
+		volumeFlagStatus.removeGroupsSet = true
+	}
+
+	//Remove All the groups
+	if updateReq.removeAllCollaborators {
+		volumeFlagStatus.removeAllCollaboratorsSet = true
+	}
+
+	// Remove all the groups
+	if updateReq.removeAllGroups {
+		volumeFlagStatus.removeAllGroupsSet = true
+	}
 
 	// check if halevel providied is valid one
 	if updateReq.halevel > 0 {
@@ -109,7 +269,7 @@ func updateVolume(cmd *cobra.Command, args []string) error {
 		updateReq.req.Spec.ReplicaSet = &api.ReplicaSet{
 			Nodes: updateReq.replicaSet,
 		}
-		updateReqSet = true
+		volumeFlagStatus.haLevelSet = true
 	}
 
 	// check prvoide size is valid
@@ -118,7 +278,7 @@ func updateVolume(cmd *cobra.Command, args []string) error {
 		updateReq.req.Spec.SizeOpt = &api.VolumeSpecUpdate_Size{
 			Size: (updateReq.size * 1024 * 1024 * 1024),
 		}
-		updateReqSet = true
+		volumeFlagStatus.sizeSet = true
 	}
 
 	// For setting volume as shared or not
@@ -127,42 +287,45 @@ func updateVolume(cmd *cobra.Command, args []string) error {
 		updateReq.req.Spec.SharedOpt = &api.VolumeSpecUpdate_Shared{
 			Shared: true,
 		}
-		updateReqSet = true
+		volumeFlagStatus.sharedSet = true
 	case "off":
 		updateReq.req.Spec.SharedOpt = &api.VolumeSpecUpdate_Shared{
 			Shared: false,
 		}
-		updateReqSet = true
+		volumeFlagStatus.sharedSet = true
 	}
 
-	// for setting volume to be sticky
+	// For setting volume to be sticky
 	switch updateReq.sticky {
 	case "on":
 		updateReq.req.Spec.StickyOpt = &api.VolumeSpecUpdate_Sticky{
 			Sticky: true,
 		}
-		updateReqSet = true
+		volumeFlagStatus.stickySet = true
 	case "off":
 		updateReq.req.Spec.StickyOpt = &api.VolumeSpecUpdate_Sticky{
 			Sticky: false,
 		}
-		updateReqSet = true
+		volumeFlagStatus.stickySet = true
 	}
 
-	if !updateReqSet {
-		return util.PxErrorMessage(err, "Must supply any one of the flags with valid parameters."+
+	if !volumeFlagStatus.addCollaboratorsSet && !volumeFlagStatus.addGroupsSet &&
+		!volumeFlagStatus.haLevelSet && !volumeFlagStatus.removeAllCollaboratorsSet &&
+		!volumeFlagStatus.removeAllGroupsSet && !volumeFlagStatus.removeCollaboratorsSet &&
+		!volumeFlagStatus.removeGroupsSet && !volumeFlagStatus.sharedSet &&
+		!volumeFlagStatus.sizeSet && !volumeFlagStatus.stickySet {
+		return fmt.Errorf("Error: Must supply any one of the flags with valid parameters. " +
 			"Please see help for more info")
 	}
 
-	// Before submitting the request, need to make sure volumespec is checked for valid flag combinations.
-	err = portworx.ValidateVolumeSpec(updateReq.req.Spec)
+	// Check whether the flag options are in valid combination.
+	err = validateVolumeUpdateOptions(volumeFlagStatus)
 	if err != nil {
-		// validation of VolumeSpec has failed, hence return failure
 		return err
 	}
 
-	volumes := api.NewOpenStorageVolumeClient(conn)
-	_, err = volumes.Update(ctx, updateReq.req)
+	volumes := api.NewOpenStorageVolumeClient(cvOps.PxVolumeOps.GetPxVolumeOpsInfo().PxConnectionData.Conn)
+	_, err = volumes.Update(cvOps.PxVolumeOps.GetPxVolumeOpsInfo().PxConnectionData.Ctx, updateReq.req)
 	if err != nil {
 		return util.PxErrorMessage(err, "Failed to patch volume")
 	}

--- a/handler/volume/volume_test/patch_test.go
+++ b/handler/volume/volume_test/patch_test.go
@@ -67,6 +67,58 @@ func TestPatchVolumeUnsetShared(t *testing.T) {
 	volCleanup(t, volName)
 }
 
+func TestPatchVolumeAddCollaborators(t *testing.T) {
+	volName := test.GenVolName("testVol")
+	volCreate(t, volName)
+	collaborators := "user2:r,user3:w"
+	//Update the collaborators list to the volume access list.
+	test.PxTestPatchVolumeAddCollaborators(t, volName, collaborators)
+	volCleanup(t, volName)
+}
+
+func TestPatchVolumeRemoveCollaborators(t *testing.T) {
+	volName := test.GenVolName("testVol")
+	volCreate(t, volName)
+	collaborators := "user1:w"
+	//Remove the collaborators list from the volume access list.
+	test.PxTestPatchVolumeRemoveCollaborators(t, volName, collaborators)
+	volCleanup(t, volName)
+}
+
+func TestPatchVolumeRemoveAllCollaborators(t *testing.T) {
+	volName := test.GenVolName("testVol")
+	volCreate(t, volName)
+	//Remove all the collaborators from the volume access list.
+	test.PxTestPatchVolumeRemoveAllCollaborators(t, volName)
+	volCleanup(t, volName)
+}
+
+func TestPatchVolumeAddGroups(t *testing.T) {
+	volName := test.GenVolName("testVol")
+	volCreate(t, volName)
+	groups := "group2:r,group3:a"
+	//Update the group list to the volume access list.
+	test.PxTestPatchVolumeAddGroups(t, volName, groups)
+	volCleanup(t, volName)
+}
+
+func TestPatchVolumeRemoveGroups(t *testing.T) {
+	volName := test.GenVolName("testVol")
+	volCreate(t, volName)
+	groups := "group1:r"
+	//Remove the group list from the volume access list.
+	test.PxTestPatchVolumeRemoveGroups(t, volName, groups)
+	volCleanup(t, volName)
+}
+
+func TestPatchVolumeRemoveAllGroups(t *testing.T) {
+	volName := test.GenVolName("testVol")
+	volCreate(t, volName)
+	//Remove All the groups from the volume access list.
+	test.PxTestPatchVolumeRemoveAllGroups(t, volName)
+	volCleanup(t, volName)
+}
+
 // Helper to create a volume
 func volCreate(t *testing.T, volName string) {
 	// Create a volume


### PR DESCRIPTION
This PR contains the changes for the following items:

1. Implemented following flag options in patch volume command for volume access.
   -  --add-collaborators ---> To add the list of collaborators to the existing list. If the collaborator already exists, the new access/permission value will be updated.
-  --add-groups ---> To add the list of groups to the existing list. If the group already exists, the new access/permission value will be updated.
-  --remove-collaborators --> To remove the list of collaborators from the existing list.
- --remove-groups --> To remove the list of groups from the existing list 
- --remove-all-collaborators --> To remove all the collaborators from volume access list.
- --remove-all-groups --> To remove all the groups from group access list.
2. Unit testcases for these flag option in the patch command unit testcase.
3. updated the common.go testcase to refer it as pxc instead of px.
4. Fix for the review comment in the previous #51 (pxc should not be sending empty objectgs, instead, only create them when needed.)

**Manual testcase Details:**
**Basic combination:**
**Step1:** Create a volume testvol100 with --collaborators user1:r,user2:w,user3:a and --groups group1:r,group2:w,group3:a
./pxc create volume testvol2 --collaborators user1:r,user2:w,user3:a --groups group1:r,group2:w,group3:a

**Step2:** Verify the volume access list with describe volume command.
 ./pxc describe volume testvol2 | grep -i "owner\|collaborators\|user\|group"

**Step3:** Update the collaborators and groups using patch volume command. --add-collaborators user4:r,user5:w,user6:a --add-groups group4:r,group5:w,group6:a
./pxc patch volume testvol2 --add-collaborators user4:r,user5:w,user6:a --add-groups group4:r,group5:w,group6:a

**Step4:** Verify the updated volume access list with describe volume command.
 ./pxc describe volume testvol2 | grep -i "owner\|collaborators\|user\|group" 

**Step5:** Update access type of the existing Collaborators and groups. --add-collaborators user4:a,user5:a,user6:a --add-groups group4:a,group5:a,group6:a
./pxc patch volume testvol2 --add-collaborators user4:a,user5:a,user6:a --add-groups group4:a,group5:a,group6:a

**Step6:**Verify the updated volume access list with describe volume command.
 ./pxc describe volume testvol2 | grep -i "owner\|collaborators\|user\|group"

**Step7:** Update access type of the existing Collaborators and groups. --add-collaborators user4:r,user5:w,user6:a --add-groups group4:r,group5:w,group6:a
./pxc patch volume testvol2 --add-collaborators user4:r,user5:w,user6:a --add-groups group4:r,group5:w,group6:a

**Step8:**Verify the updated volume access list with describe volume command.
 ./pxc describe volume testvol2 | grep -i "owner\|collaborators\|user\|group"

**Step9:** Remove the newly update collaborators and groups --remove-collabortators user4:r,user5:w,user6:a --remove-groups group4:r,group5:w,group6:a
./pxc patch volume testvol2 --remove-collaborators user4:r,user5:w,user6:a --remove-groups group4:r,group5:w,group6:a

**Step10:** Verify the updated volume access list with describe volume command
./pxc describe volume testvol2 | grep -i "owner\|collaborators\|user\|group"

**Step11:** Update the collaborators using patch command --add-collaborators user4:r,user5:w,user6:a
./pxc patch volume testvol2 --add-collaborators user4:r,user5:w,user6:a

**Step12:** Verify the updated  volume access list with describe volume command
./pxc describe volume testvol2 | grep -i "owner\|collaborators\|user\|group"

**Step13:** Update the groups and remove the collaborators that was added in the previous step --add-groups group4:r,group5:w,group6:a --remove-collaborators user4:r,user5:w,user6:a
./pxc patch volume testvol2 --add-groups group4:r,group5:w,group6:a --remove-collaborators user4:r,user5:w,user6:a

**Step14:** Verify the updated volume access list with describe volume command.
./pxc describe volume testvol2 | grep -i "owner\|collaborators\|user\|group"

**Step15:** Remove All the collaborators and groups. --remove-all-collaborators and --remove-all-groups.
./pxc patch volume testvol2 --remove-all-collaborators --remove-all-collaborators

**Step16:** Verify that the collaborators and groups list is empty with the volume describe command.
./pxc describe volume testvol2 | grep -i "owner\|collaborators\|user\|group"

**Invalid combination:**
**Step1:** Try --add-collaborators and --remove-all-collaborators command.
./pxc patch volume testvol2 --add-collaborators group1:r --remove-all-collaborators

**Step2:** Try --add-groups and --remove-all-groups command.
./pxc patch volume testvol2 --add-groups group1:r --remove-all-groups

**Step3:** Try --remove-collaborators and remove-all-collaborators command.
./pxc patch volume testvol2 --remove-collaborators user1:r --remove-all-collaborators

**step4:** Try --remove-groups and remove-all-groups command.
./pxc patch volume testvol2 --remove-groups group1:r --remove-all-groups
  
The results of the manual testing is attached in the file.