### PR TITLE
Added examples for cluster, context, clusterpair command

### DIFF
--- a/handler/cloudmigration/create.go
+++ b/handler/cloudmigration/create.go
@@ -45,8 +45,15 @@ var _ = commander.RegisterCommandVar(func() {
 	createCloudmigrationCmd = &cobra.Command{
 		Use:   "cloudmigration",
 		Short: "Start a cloud migration",
-		Long:  `TODO Add long description`,
-		RunE:  createCloudmigrationExec,
+		Long:  `Migrates set of volumes or a particualr volume or a group from cluster pair`,
+		Example: `
+  # Migrating all volumes from cluster 9548a6e0-053b-43fb-8d26-42b628d6c405:
+  pxc create cloudmigration --all -c 9548a6e0-053b-43fb-8d26-42b628d6c405
+
+  # Migrating particualar volume from clusterpair
+  # Here volid 134771906220836406 is being migrated:
+  pxc create cloudmigration --volume-id 134771906220836406`,
+		RunE: createCloudmigrationExec,
 	}
 })
 

--- a/handler/cluster/describe.go
+++ b/handler/cluster/describe.go
@@ -30,11 +30,12 @@ var describeClusterCmd *cobra.Command
 var _ = commander.RegisterCommandVar(func() {
 	// describeClusterCmd represents the describeCluster command
 	describeClusterCmd = &cobra.Command{
-		Use:     "cluster",
-		Short:   "Describe a Portworx cluster",
-		Long:    "Show detailed information of Portworx cluster",
-		Example: `$ pxc describe cluster`,
-
+		Use:   "cluster",
+		Short: "Describe a Portworx cluster",
+		Long:  "Show detailed information of Portworx cluster",
+		Example: `
+  # Display detailed information about Portworx cluster:
+  pxc describe cluster`,
 		RunE: describeClusterExec,
 	}
 })

--- a/handler/clusterpair/create.go
+++ b/handler/clusterpair/create.go
@@ -50,11 +50,11 @@ var _ = commander.RegisterCommandVar(func() {
 		Use:     "clusterpair",
 		Aliases: []string{"clusterpairs"},
 		Short:   "Pair this cluster with another Portworx cluster",
-		Example: "$ pxc create clusterpair TODO ADD EXAMPLEs",
-		Long: `TODO
-
-ADD EXAMPLES
-	`,
+		Example: `
+  # Creates a cluster pair from two Portworx cluster
+  # Here pxcluster1(source) and pxcluster2(destination) are two different Portworx cluster:
+  pxc create clusterpair -s pxcluster1 -d pxcluster2`,
+		Long: `Creates a cluster pair between two Portworx clusters`,
 		RunE: createClusterpairExec,
 	}
 })

--- a/handler/context/current.go
+++ b/handler/context/current.go
@@ -31,7 +31,10 @@ var _ = commander.RegisterCommandVar(func() {
 		Use:     "current",
 		Aliases: []string{"show", "current-context"},
 		Short:   "Show current context name",
-		RunE:    contextCurrentExec,
+		Example: `
+  # Display current used context information:
+  pxc context current`,
+		RunE: contextCurrentExec,
 	}
 })
 

--- a/handler/context/delete.go
+++ b/handler/context/delete.go
@@ -29,18 +29,18 @@ var contextDeleteCmd *cobra.Command
 
 var _ = commander.RegisterCommandVar(func() {
 	contextDeleteCmd = &cobra.Command{
-		Use:     "delete [NAME]",
-		Short:   "Deletes the given context",
-		Example: "$ pxc context delete mycontext",
+		Use:   "delete [NAME]",
+		Short: "Deletes the given context",
+		Example: `
+  # Delete context called mycontext:
+  pxc context delete mycontext`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return fmt.Errorf("Must supply a name for context")
 			}
 			return nil
 		},
-		Long: `Usage:
-px context delete --name context1
-	`,
+		Long: `Deletes user provided context from config.yaml file`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return contextDeleteExec(cmd, args)
 		},

--- a/handler/context/list.go
+++ b/handler/context/list.go
@@ -30,8 +30,10 @@ var _ = commander.RegisterCommandVar(func() {
 		Use:     "list",
 		Aliases: []string{"contexts", "ctx"},
 		Short:   "List all context configurations",
-		Long: `List all context configurations
-px get context`,
+		Long:    `List all available context configurations from config.yaml file`,
+		Example: `
+  # List all context configurations:
+  pxc context list`,
 		RunE: contextListExec,
 	}
 })

--- a/handler/context/set.go
+++ b/handler/context/set.go
@@ -31,8 +31,10 @@ var _ = commander.RegisterCommandVar(func() {
 	contextSetCmd = &cobra.Command{
 		Use:     "set [NAME]",
 		Aliases: []string{"use"},
-		Example: "$ pxc context set mynewcontext",
-		Short:   "Set the current context configuration",
+		Example: `
+  # Set the current context to mynewcontext:
+  pxc context set mynewcontext`,
+		Short: "Set the current context configuration",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return fmt.Errorf("Must supply a name for context")

--- a/handler/context/unset.go
+++ b/handler/context/unset.go
@@ -29,6 +29,9 @@ var _ = commander.RegisterCommandVar(func() {
 		Use:   "unset",
 		Short: "Unset the current context configuration",
 		Long:  ``,
+		Example: `
+  # Unsetting context called mycontext:
+  pxc context mycontext`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return contextUnsetExec(cmd, args)
 		},


### PR DESCRIPTION
Added examples for cluster, context, clusterpair, cloud migration commands.