### PR TITLE
Added support for time based, severity alert options.

### DIFF
--- a/handler/alerts/get.go
+++ b/handler/alerts/get.go
@@ -43,8 +43,20 @@ var _ = commander.RegisterCommandVar(func() {
   # To get portworx related alerts :
   pxc get alerts
 
-  # To fetch alert based on particualr alert id. Fetch all alerts based on "VolumeCreateSuccess" id
-  pxc get alerts --id "VolumeCreateSuccess"`,
+  # To fetch alert based on particualr alert id. Fetch all alerts based on "VolumeCreateSuccess" id :
+  pxc get alerts --id "VolumeCreateSuccess"
+
+  # To fetch alerts between a time window :
+  pxctl alerts show --start-time "2019-09-19T09:40:26.371Z" --end-time "2019-09-19T09:43:59.371Z"
+
+  # To fetch alerts with min severity level :
+  pxc get alerts --severity "alarm"
+
+  # To fetch alerts based on resource type. Here we fetch all "volume" related alerts :
+  pxc get alerts -t "volume"
+
+  # To fetch alerts based on resource id. Here we fetch alerts related to "cluster" :
+  pxc get alerts --id "1f95a5e7-6a38-41f9-9cb2-8bb4f8ab72c5"`,
 		RunE: getAlertsExec,
 	}
 })
@@ -53,8 +65,10 @@ var _ = commander.RegisterCommandInit(func() {
 	cmd.GetAddCommand(getAlertsCmd)
 	getAlertsCmd.Flags().StringP("type", "t", "all", "alert type (Valid Values: [volume node cluster drive all])")
 	getAlertsCmd.Flags().StringP("id", "i", "", "Alert id ")
+	getAlertsCmd.Flags().StringP("start-time", "a", "", "start time span (RFC 3339)")
+	getAlertsCmd.Flags().StringP("end-time", "e", "", "end time span (RFC 3339)")
 	getAlertsCmd.Flags().StringP("output", "o", "", "Output in yaml|json|wide")
-	//TODO: Need to support more flags
+	getAlertsCmd.Flags().StringP("severity", "v", "notify", "Min severity value (Valid Values: [notify warn warning alarm]) (default \"notify\")")
 })
 
 func GetAddCommand(cmd *cobra.Command) {
@@ -94,7 +108,7 @@ func NewAlertGetFormatter(cvOps *cliops.CliAlertOps) *alertGetFormatter {
 
 // YamlFormat returns the yaml representation of the object
 func (p *alertGetFormatter) YamlFormat() (string, error) {
-	alerts, err := p.PxAlertOps.GetPxAlerts(p.CliAlertInputs.AlertType, p.CliAlertInputs.AlertId)
+	alerts, err := p.PxAlertOps.GetPxAlerts(p.CliAlertInputs)
 	if err != nil {
 		return "", err
 	}
@@ -103,7 +117,7 @@ func (p *alertGetFormatter) YamlFormat() (string, error) {
 
 // JsonFormat returns the json representation of the object
 func (p *alertGetFormatter) JsonFormat() (string, error) {
-	alerts, err := p.PxAlertOps.GetPxAlerts(p.CliAlertInputs.AlertType, p.CliAlertInputs.AlertId)
+	alerts, err := p.PxAlertOps.GetPxAlerts(p.CliAlertInputs)
 	if err != nil {
 		return "", err
 	}
@@ -126,7 +140,7 @@ func (p *alertGetFormatter) toTabbed() (string, error) {
 	writer := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
 	t := tabby.NewCustom(writer)
 
-	alerts, err := p.PxAlertOps.GetPxAlerts(p.CliAlertInputs.AlertType, p.CliAlertInputs.AlertId)
+	alerts, err := p.PxAlertOps.GetPxAlerts(p.CliAlertInputs)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/cliops/alertops.go
+++ b/pkg/cliops/alertops.go
@@ -21,34 +21,33 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type CliAlertInputs struct {
-	util.BaseFormatOutput
-	Wide      bool
-	AlertType string
-	AlertId   string
-}
-
 type CliAlertOps struct {
-	CliAlertInputs
+	portworx.CliAlertInputs
 	PxAlertOps portworx.PxAlertOps
 }
 
-func GetCliAlertInputs(cmd *cobra.Command, args []string) *CliAlertInputs {
+func GetCliAlertInputs(cmd *cobra.Command, args []string) *portworx.CliAlertInputs {
 	output, _ := cmd.Flags().GetString("output")
 	alertType, _ := cmd.Flags().GetString("type")
 	alertId, _ := cmd.Flags().GetString("id")
-	return &CliAlertInputs{
+	startTime, _ := cmd.Flags().GetString("start-time")
+	endTime, _ := cmd.Flags().GetString("end-time")
+	severity, _ := cmd.Flags().GetString("severity")
+	return &portworx.CliAlertInputs{
 		BaseFormatOutput: util.BaseFormatOutput{
 			FormatType: output,
 		},
 		AlertType: alertType,
 		AlertId:   alertId,
+		StartTime: startTime,
+		EndTime:   endTime,
+		Severity:  severity,
 	}
 }
 
 // Create a new cliAlertOps object
 func NewCliAlertOps(
-	cvi *CliAlertInputs,
+	cvi *portworx.CliAlertInputs,
 ) *CliAlertOps {
 	return &CliAlertOps{
 		CliAlertInputs: *cvi,


### PR DESCRIPTION
Added following options to fetch alerts
1. Time-based i.,e between the start and end time
2. Fetch alerts based on severity level.
```

pxctl alerts show --start-time "2019-09-19T09:40:26.371Z" --end-time "2019-09-19T09:43:59.371Z"


Prashanths-MacBook-Pro:pxc prashanthkumar$ ./pxc get alerts
Id                   Severity  Count  LastSeen                  FirstSeen                 Description
--                   --------  -----  --------                  ---------                 -----------
NodeStartFailure     ALARM     1      Sep 17 05:19:56 UTC 2019  Sep 17 05:19:56 UTC 2019  Node 70.0.79.19 Entering Maintenance mode: User Initiated
VolumeDeleteSuccess  NOTIFY    1      Sep 21 14:59:01 UTC 2019  Sep 21 14:59:01 UTC 2019  Volume (Name: testvol2 Id: 387831705717803666) deleted successfully.
VolumeCreateSuccess  NOTIFY    1      Sep 21 14:59:09 UTC 2019  Sep 21 14:59:09 UTC 2019  Volume (Name: testvol3 Id: 187222892079114431) created successfully.
VolumeDeleteSuccess  NOTIFY    1      Sep 21 14:59:21 UTC 2019  Sep 21 14:59:21 UTC 2019  Volume (Name: testvol3 Id: 187222892079114431) deleted successfully.
VolumeCreateSuccess  NOTIFY    1      Sep 21 15:02:51 UTC 2019  Sep 21 15:02:51 UTC 2019  Volume (Name: testvol4 Id: 1011977456030154762) created successfully.

Prashanths-MacBook-Pro:pxc prashanthkumar$ ./pxc get alerts --start-time "2019-09-16T09:40:26.371Z" --end-time "2019-09-21T14:59:01.371Z"
Id                   Severity  Count  LastSeen                  FirstSeen                 Description
--                   --------  -----  --------                  ---------                 -----------
NodeStartFailure     ALARM     1      Sep 17 05:19:56 UTC 2019  Sep 17 05:19:56 UTC 2019  Node 70.0.79.19 Entering Maintenance mode: User Initiated
VolumeDeleteSuccess  NOTIFY    1      Sep 21 14:59:01 UTC 2019  Sep 21 14:59:01 UTC 2019  Volume (Name: testvol2 Id: 387831705717803666) deleted successfully.


Prashanths-MacBook-Pro:pxc prashanthkumar$ ./pxc get alerts --severity "alarm"
Id                Severity  Count  LastSeen                  FirstSeen                 Description
--                --------  -----  --------                  ---------                 -----------
NodeStartFailure  ALARM     1      Sep 21 15:08:36 UTC 2019  Sep 21 15:08:36 UTC 2019  Node 70.0.79.19 Entering Maintenance mode: User Initiated


Prashanths-MacBook-Pro:pxc prashanthkumar$ ./pxc get alerts --severity "dsffsfsd"
Invalid severity level

Prashanths-MacBook-Pro:pxc prashanthkumar$ ./pxc get alerts -t "voluffsdf"
Invalid type provided
Prashanths-MacBook-Pro:pxc prashanthkumar$


```