### PR TITLE
Add pxc auth guest-access commands

### DIFF
--- a/handler/auth/auth.go
+++ b/handler/auth/auth.go
@@ -1,0 +1,45 @@
+/*
+Copyright © 2020 Portworx
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package auth
+
+import (
+	"github.com/portworx/pxc/cmd"
+	"github.com/portworx/pxc/pkg/commander"
+	"github.com/portworx/pxc/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+// authCmd represents the cluster command
+var authCmd *cobra.Command
+
+var _ = commander.RegisterCommandVar(func() {
+	authCmd = &cobra.Command{
+		Use:   "auth",
+		Short: "Manage Portworx authentication",
+		Run: func(cmd *cobra.Command, args []string) {
+			util.Printf("Please see pxc auth --help for more commands\n")
+		},
+	}
+})
+
+var _ = commander.RegisterCommandInit(func() {
+	cmd.RootAddCommand(authCmd)
+})
+
+// AuthAddCommand adds a command to the auth handler
+func AuthAddCommand(cmd *cobra.Command) {
+	authCmd.AddCommand(cmd)
+}

--- a/handler/auth/guestaccess/disable.go
+++ b/handler/auth/guestaccess/disable.go
@@ -1,0 +1,62 @@
+/*
+Copyright © 2020 Portworx
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package guestaccess
+
+import (
+	"github.com/portworx/pxc/pkg/cliops"
+	"github.com/portworx/pxc/pkg/commander"
+	"github.com/portworx/pxc/pkg/portworx"
+	"github.com/portworx/pxc/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+var disableGuestAccessCmd *cobra.Command
+
+var _ = commander.RegisterCommandVar(func() {
+	disableGuestAccessCmd = &cobra.Command{
+		Use:   "disable",
+		Short: "Disable guest access role",
+		RunE:  disableGuestAccessExec,
+	}
+})
+
+var _ = commander.RegisterCommandInit(func() {
+	GuestAccessAddCommand(disableGuestAccessCmd)
+})
+
+func disableGuestAccessExec(cmd *cobra.Command, args []string) error {
+	ctx, conn, err := portworx.PxConnectDefault()
+	_ = ctx
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	// Parse out all of the common cli volume flags
+	cai := cliops.GetCliAuthInputs(cmd, args)
+
+	// Create a cliVolumeOps object
+	authOps := cliops.NewCliAuthOps(cai)
+
+	// initialize alertOP interface
+	authOps.AuthOps = portworx.NewAuthOps()
+
+	err = authOps.AuthOps.UpdateRole(&portworx.RoleGuestDisabled)
+	if err == nil {
+		util.Printf("Guest access disabled successfully\n")
+	}
+
+	return err
+}

--- a/handler/auth/guestaccess/enable.go
+++ b/handler/auth/guestaccess/enable.go
@@ -1,0 +1,62 @@
+/*
+Copyright © 2020 Portworx
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package guestaccess
+
+import (
+	"github.com/portworx/pxc/pkg/cliops"
+	"github.com/portworx/pxc/pkg/commander"
+	"github.com/portworx/pxc/pkg/portworx"
+	"github.com/portworx/pxc/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+var enableGuestAccessCmd *cobra.Command
+
+var _ = commander.RegisterCommandVar(func() {
+	enableGuestAccessCmd = &cobra.Command{
+		Use:   "enable",
+		Short: "enable guest access role",
+		RunE:  enableGuestAccessExec,
+	}
+})
+
+var _ = commander.RegisterCommandInit(func() {
+	GuestAccessAddCommand(enableGuestAccessCmd)
+})
+
+func enableGuestAccessExec(cmd *cobra.Command, args []string) error {
+	ctx, conn, err := portworx.PxConnectDefault()
+	_ = ctx
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	// Parse out all of the common cli volume flags
+	cai := cliops.GetCliAuthInputs(cmd, args)
+
+	// Create a cliVolumeOps object
+	authOps := cliops.NewCliAuthOps(cai)
+
+	// initialize alertOP interface
+	authOps.AuthOps = portworx.NewAuthOps()
+
+	err = authOps.AuthOps.UpdateRole(&portworx.RoleGuestEnabled)
+	if err == nil {
+		util.Printf("Guest access enabled successfully\n")
+	}
+
+	return err
+}

--- a/handler/auth/guestaccess/guestaccess.go
+++ b/handler/auth/guestaccess/guestaccess.go
@@ -1,0 +1,46 @@
+/*
+Copyright © 2020 Portworx
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package guestaccess
+
+import (
+	"github.com/portworx/pxc/handler/auth"
+	"github.com/portworx/pxc/pkg/commander"
+	"github.com/portworx/pxc/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+// guestAccessCmd represents the alert command
+var guestAccessCmd *cobra.Command
+
+var _ = commander.RegisterCommandVar(func() {
+	guestAccessCmd = &cobra.Command{
+		Use:     "guest-access",
+		Aliases: []string{"ga"},
+		Short:   "Manage guest access on a Portworx cluster",
+		Run: func(cmd *cobra.Command, args []string) {
+			util.Printf("Please see pxc auth guest-access --help for more commands\n")
+		},
+	}
+})
+
+var _ = commander.RegisterCommandInit(func() {
+	auth.AuthAddCommand(guestAccessCmd)
+})
+
+// GuestAccessAddCommand adds a guest access command
+func GuestAccessAddCommand(cmd *cobra.Command) {
+	guestAccessCmd.AddCommand(cmd)
+}

--- a/handler/auth/guestaccess/show.go
+++ b/handler/auth/guestaccess/show.go
@@ -1,0 +1,113 @@
+/*
+Copyright © 2020 Portworx
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package guestaccess
+
+import (
+	"github.com/portworx/pxc/pkg/cliops"
+	"github.com/portworx/pxc/pkg/commander"
+	"github.com/portworx/pxc/pkg/portworx"
+	"github.com/portworx/pxc/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+var showGuestAccessCmd *cobra.Command
+
+var _ = commander.RegisterCommandVar(func() {
+	showGuestAccessCmd = &cobra.Command{
+		Use:   "show",
+		Short: "show guest access role",
+		RunE:  showGuestAccessExec,
+	}
+})
+
+var _ = commander.RegisterCommandInit(func() {
+	GuestAccessAddCommand(showGuestAccessCmd)
+
+	showGuestAccessCmd.Flags().StringP("output", "o", "", "Output in yaml|json|wide")
+})
+
+func showGuestAccessExec(cmd *cobra.Command, args []string) error {
+	ctx, conn, err := portworx.PxConnectDefault()
+	_ = ctx
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	// Parse out all of the common cli volume flags
+	cai := cliops.GetCliAuthInputs(cmd, args)
+
+	// Create a cliVolumeOps object
+	authOps := cliops.NewCliAuthOps(cai)
+
+	// initialize alertOP interface
+	authOps.AuthOps = portworx.NewAuthOps()
+
+	// Create the parser object
+	authgf := NewGuestAccessShowFormatter(authOps)
+	return util.PrintFormatted(authgf)
+}
+
+type guestAccessShowFormatter struct {
+	cliops.CliAuthOps
+}
+
+// NewGuestAccessShowFormatter creates a new guest access formatter
+func NewGuestAccessShowFormatter(cvOps *cliops.CliAuthOps) *guestAccessShowFormatter {
+	return &guestAccessShowFormatter{
+		CliAuthOps: *cvOps,
+	}
+}
+
+// YamlFormat returns the yaml representation of the object
+func (f *guestAccessShowFormatter) YamlFormat() (string, error) {
+	role, err := f.AuthOps.GetRole("system.guest")
+	if err != nil {
+		return "", err
+	}
+	return util.ToYaml(role)
+}
+
+// JsonFormat returns the json representation of the object
+func (f *guestAccessShowFormatter) JsonFormat() (string, error) {
+	role, err := f.AuthOps.GetRole("system.guest")
+	if err != nil {
+		return "", err
+	}
+	return util.ToJson(role)
+}
+
+// WideFormat returns the wide string representation of the object
+func (f *guestAccessShowFormatter) WideFormat() (string, error) {
+	f.Wide = true
+	return f.DefaultFormat()
+}
+
+// DefaultFormat returns the default string representation of the object
+func (f *guestAccessShowFormatter) DefaultFormat() (string, error) {
+	role, err := f.AuthOps.GetRole("system.guest")
+	if err != nil {
+		return "", err
+	}
+
+	if role.String() == portworx.RoleGuestDisabled.String() {
+		util.Printf("Guest access disabled\n")
+
+	} else {
+		util.Printf("Guest access enabled\n")
+	}
+
+	return "", nil
+}

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2019 Portworx
+Copyright © 2020 Portworx
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,7 +16,11 @@ limitations under the License.
 package handler
 
 import (
+	// import all handlers to register them
+	_ "github.com/portworx/pxc/handler/auth"
+	_ "github.com/portworx/pxc/handler/auth/guestaccess"
 	_ "github.com/portworx/pxc/handler/cluster"
+	_ "github.com/portworx/pxc/handler/cluster/alerts"
 	_ "github.com/portworx/pxc/handler/config"
 	_ "github.com/portworx/pxc/handler/login"
 	_ "github.com/portworx/pxc/handler/node"

--- a/pkg/cliops/authops.go
+++ b/pkg/cliops/authops.go
@@ -1,0 +1,47 @@
+/*
+Copyright © 2020 Portworx
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cliops
+
+import (
+	"github.com/portworx/pxc/pkg/portworx"
+	"github.com/portworx/pxc/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+// CliAuthOps represents an interface for auth commands
+type CliAuthOps struct {
+	portworx.CliAuthInputs
+	AuthOps portworx.AuthOps
+}
+
+// GetCliAuthInputs gets all CLI auth inputs
+func GetCliAuthInputs(cmd *cobra.Command, args []string) *portworx.CliAuthInputs {
+	output, _ := cmd.Flags().GetString("output")
+	return &portworx.CliAuthInputs{
+		BaseFormatOutput: util.BaseFormatOutput{
+			FormatType: output,
+		},
+	}
+}
+
+// NewCliAuthOps creates a new cliAuthOps object
+func NewCliAuthOps(
+	cvi *portworx.CliAuthInputs,
+) *CliAuthOps {
+	return &CliAuthOps{
+		CliAuthInputs: *cvi,
+	}
+}

--- a/pkg/portworx/authops.go
+++ b/pkg/portworx/authops.go
@@ -1,0 +1,114 @@
+/*
+Copyright © 2020 Portworx
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portworx
+
+import (
+	"github.com/portworx/pxc/pkg/util"
+
+	api "github.com/libopenstorage/openstorage-sdk-clients/sdk/golang"
+)
+
+// RoleGuestDisabled indicates that the system.guest is disabled
+var RoleGuestDisabled = api.SdkRole{
+	Name: "system.guest",
+	Rules: []*api.SdkRule{
+		{
+			Services: []string{"!*"},
+			Apis:     []string{"!*"},
+		},
+	},
+}
+
+// RoleGuestEnabled indicates that the system.guest is enabled
+var RoleGuestEnabled = api.SdkRole{
+	Name: "system.guest",
+	Rules: []*api.SdkRule{
+		{
+			Services: []string{"mountattach", "volume", "cloudbackup", "migrate"},
+			Apis:     []string{"*"},
+		},
+		{
+			Services: []string{"identity"},
+			Apis:     []string{"version"},
+		},
+		{
+			Services: []string{
+				"cluster",
+				"node",
+			},
+			Apis: []string{
+				"inspect*",
+				"enumerate*",
+			},
+		},
+	},
+}
+
+// AuthOps represents all auth related commands
+type AuthOps interface {
+	UpdateRole(r *api.SdkRole) error
+	GetRole(name string) (*api.SdkRole, error)
+}
+
+// CliAuthInputs represents input for auth commands
+type CliAuthInputs struct {
+	util.BaseFormatOutput
+	Wide bool
+}
+
+type authOps struct{}
+
+// NewAuthOps creates a new auth ops
+func NewAuthOps() AuthOps {
+	return &authOps{}
+}
+
+func (p *authOps) GetRole(name string) (*api.SdkRole, error) {
+	ctx, conn, err := PxConnectDefault()
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	roles := api.NewOpenStorageRoleClient(conn)
+	resp, err := roles.Inspect(ctx, &api.SdkRoleInspectRequest{
+		Name: name,
+	})
+	if err != nil {
+		return nil, util.PxErrorMessage(err, "Failed to get role")
+	}
+
+	return resp.GetRole(), nil
+}
+
+func (p *authOps) UpdateRole(r *api.SdkRole) error {
+	ctx, conn, err := PxConnectDefault()
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	roles := api.NewOpenStorageRoleClient(conn)
+	_, err = roles.Update(ctx, &api.SdkRoleUpdateRequest{
+		Role: r,
+	})
+	if err != nil {
+		return util.PxErrorMessage(err, "Failed to update role")
+	}
+
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>

Tested - 

```
[grant@PDC4-SM26-N8 pxc]$ kk pxc auth guest-access enable
Guest access enabled successfully
[grant@PDC4-SM26-N8 pxc]$ kk pxc auth guest-access show
Guest access enabled

[grant@PDC4-SM26-N8 pxc]$ kk pxc auth guest-access disable
Guest access disabled successfully
[grant@PDC4-SM26-N8 pxc]$ kk pxc auth guest-access show
Guest access disabled

[grant@PDC4-SM26-N8 pxc]$ kk pxc auth guest-access show -o yaml
name: system.guest
rules:
- services:
  - '!*'
  apis:
  - '!*'
  xxx_nounkeyedliteral: {}
  xxx_unrecognized: []
  xxx_sizecache: 0
xxx_nounkeyedliteral: {}
xxx_unrecognized: []
xxx_sizecache: 0

[grant@PDC4-SM26-N8 pxc]$ kk pxc auth guest-access show -o json
{
  "name": "system.guest",
  "rules": [
    {
      "services": [
        "!*"
      ],
      "apis": [
        "!*"
      ]
    }
  ]
}

```