### PR TITLE
I HATE YOU GO MOD

### DIFF
--- a/vendor/github.com/golang/protobuf/protoc-gen-go/generator/generator.go
+++ b/vendor/github.com/golang/protobuf/protoc-gen-go/generator/generator.go
@@ -39,13 +39,6 @@ import (
 	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"
 )
 
-func init() {
-	fmt.Fprint(os.Stderr,
-		"WARNING: Package \"github.com/golang/protobuf/protoc-gen-go/generator\" is deprecated.\n"+
-			"\tA future release of golang/protobuf will delete this package,\n"+
-			"\twhich has long been excluded from the compatibility promise.\n\n")
-}
-
 // generatedCodeVersion indicates a version of the generated code.
 // It is incremented whenever an incompatibility between the generated code and
 // proto package is introduced; the generated code references


### PR DESCRIPTION
This is the only way I could figure out how to fix this issue.
I tried to update, or force update, go mod to pull grpc-gateway v2.3.0
but it will not. It always falls back to 1.9.0 because spf13/cobra
has that version in its go.mod/sum.

Closes #181

Signed-off-by: Luis Pabón <lpabon@purestorage.com>