### PR TITLE
only choose from nodes in same k8s cluster

### DIFF
--- a/component/pxctl/pxc-pxctl
+++ b/component/pxctl/pxc-pxctl
@@ -32,7 +32,10 @@ if [ "$1" = "-n" ] ; then
 	NODE=$2
 	shift 2
 else
-	nodes=$(kubectl pxc node list -o json | jq -r '.[].hostname')
+	k8snodes=$(kubectl get pod -n ${PXC_PORTWORX_SERVICE_NAMESPACE} -lname=portworx -o jsonpath='{.items[*].spec.nodeName}')
+	pxnodes=$(kubectl pxc node list -o json | jq -r '.[].hostname')
+	# Find all nodes common to both $k8snodes and $pxnodes
+	nodes=$(comm -12 <(echo $pxnodes | tr ' ' '\n' | sort) <(echo $k8snodes | tr ' ' '\n' | sort))
 	for node in $nodes ; do
 		status=$(kubectl pxc node get $node -o json | jq -r '.[].status')
 		if [ $status -eq 2 ] ; then


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

In a Metro deployment, pxc will try and run pxctl on any node in the PX cluster. In a failover scenario, there is a 50/50 chance it will choose a node that is not available.