### PR TITLE
PWX-28163-pt2: Auto-TLS support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,12 +24,10 @@ endif
 
 ifdef APP_SUFFIX
   VERSION = $(VER)-$(subst /,-,$(APP_SUFFIX))
-else
-ifeq (master,$(BRANCH))
+else ifeq (master,$(BRANCH))
   VERSION = $(VER)
 else
   VERSION = $(VER)-$(BRANCH)
-endif
 endif
 
 LDFLAGS := $(BUILDFLAGS) -ldflags "-X github.com/portworx/pxc/cmd.PxVersion=$(VERSION) $(PXC_LDFLAGS)"
@@ -45,17 +43,23 @@ endif
 ZIPPACKAGE := $(CLINAME)-$(VERSION).$(GOOS).$(ARCH).zip
 TGZPACKAGE := $(CLINAME)-$(VERSION).$(GOOS).$(ARCH).tar.gz
 
+.PHONY: dist all clean darwin_amd64_dist windows_amd64_dist linux_amd64_dist \
+	install docker-release release pxc test
+
 all: pxc $(PLUGIN_PKG_NAME)
 
 install: all
 	cp $(PKG_NAME) $(GOPATH)/bin
 	cp $(PKG_NAME) $(GOPATH)/bin/$(PLUGIN_PKG_NAME)
 
-imports:
-	goimports -w ./cmd
-	goimports -w ./handler
-	goimports -w ./pkg
-	goimports -w *.go
+$(GOPATH)/bin/goimports:
+	go install golang.org/x/tools/cmd/goimports@latest
+
+imports: $(GOPATH)/bin/goimports
+	$(GOPATH)/bin/goimports -w ./cmd
+	$(GOPATH)/bin/goimports -w ./handler
+	$(GOPATH)/bin/goimports -w ./pkg
+	$(GOPATH)/bin/goimports -w *.go
 
 lint:
 	go list ./... | grep -v /vendor/ | xargs -L1 golint -set_exit_status
@@ -131,7 +135,4 @@ $(TGZPACKAGE): all
 clean:
 	rm -f $(PKG_NAME) $(PLUGIN_PKG_NAME)
 	rm -rf dist
-
-.PHONY: dist all clean darwin_amd64_dist windows_amd64_dist linux_amd64_dist \
-	install docker-release release pxc test
 

--- a/handler/config/view.go
+++ b/handler/config/view.go
@@ -57,7 +57,7 @@ func viewExec(cmd *cobra.Command, args []string) error {
 
 	for _, cluster := range configInfo.Clusters {
 		if len(cluster.CACertData) != 0 {
-			cluster.CACertData = []byte("<REDACTED>")
+			cluster.CACertData = "<REDACTED>"
 		}
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -51,8 +51,7 @@ type Context struct {
 // Cluster provides information on how to connect to Portworx
 type Cluster struct {
 	Name       string `json:"name,omitempty" yaml:"name,omitempty"`
-	CACert     string `json:"cacert,omitempty" yaml:"cacert,omitempty"`
-	CACertData []byte `json:"cacert-data,omitempty" yaml:"cacert-data,omitempty"`
+	CACertData string `json:"certificate-authority-data,omitempty" yaml:"certificate-authority-data,omitempty"`
 	Endpoint   string `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
 	Secure     bool   `json:"secure,omitempty" yaml:"secure,omitempty"`
 

--- a/pkg/kubernetes/portforward.go
+++ b/pkg/kubernetes/portforward.go
@@ -96,12 +96,12 @@ func (p *KubectlPortForwarder) Start() error {
 
 	args := config.KM().KubectlFlagsToCliArgs()
 	currentCluster := config.CM().GetCurrentCluster()
-	logrus.Debugf("port-forward: CurrentCluster: %v", *currentCluster)
+	logrus.Debugf("port-forward: CurrentCluster: %#v", *currentCluster)
 	args = args + fmt.Sprintf("-n %s port-forward svc/%s :%s",
 		currentCluster.TunnelServiceNamespace,
 		currentCluster.TunnelServiceName,
 		currentCluster.TunnelServicePort)
-	logrus.Debugf("port-forward: args [%s]", args)
+	logrus.Debugf("port-forward: running \"kubectl %s\"", args)
 
 	cmd := exec.Command("kubectl", strings.Split(args, " ")...)
 
@@ -123,6 +123,7 @@ func (p *KubectlPortForwarder) Start() error {
 		logrus.Errorf("Error while executing [%s]: %v", cmd.String(), err)
 		return fmt.Errorf("Unable to execute kubectl. Please make sure kubectl is in your path")
 	}
+	logrus.Debug("port-forward: started")
 	p.cmd = cmd
 
 	// Read the port

--- a/pkg/util/tls.go
+++ b/pkg/util/tls.go
@@ -1,0 +1,78 @@
+package util
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"github.com/sirupsen/logrus"
+	"net"
+)
+
+// AppendCertPool returns system CA pool, with optional addition of <cadata> CA certificate
+func AppendCertPool(cadata []byte) *x509.CertPool {
+	capool, err := x509.SystemCertPool()
+	if err != nil {
+		logrus.WithError(err).Warnf("Could not get the system CA pool")
+		capool = x509.NewCertPool()
+	}
+
+	if len(cadata) != 0 {
+		if !capool.AppendCertsFromPEM(cadata) {
+			logrus.Warn("could not append custom certificate")
+		}
+	}
+
+	return capool
+}
+
+// VerifyConnection will check the connection (host:port endpoint), including the SSL validation
+func VerifyConnection(endpoint string, isSecure *bool, cabytes []byte) error {
+	ep := endpoint
+	if ep == "" {
+		ep = "127.0.0.1:9020"
+	}
+	ephost, _, err := net.SplitHostPort(ep)
+	if err != nil {
+		return fmt.Errorf("invalid endpoint: %s", err)
+	}
+	conf := &tls.Config{
+		InsecureSkipVerify: true,
+	}
+	var capool *x509.CertPool
+	if len(cabytes) > 0 {
+		logrus.Debug("Appending custom CA certificate")
+		capool = AppendCertPool(cabytes)
+		conf = &tls.Config{
+			RootCAs: capool,
+		}
+	}
+
+	logrus.Debugf("Connecting to %s", ep)
+	conn, err := tls.Dial("tcp", ep, conf)
+	if err != nil {
+		return fmt.Errorf("error connecting to %s: %s", ep, err)
+	}
+	defer conn.Close()
+
+	// verify certs
+	if certs := conn.ConnectionState().PeerCertificates; len(certs) > 0 {
+		logrus.Debug("Checking TLS certificate")
+		_, err = conn.ConnectionState().PeerCertificates[0].Verify(x509.VerifyOptions{
+			DNSName:   ephost,
+			Roots:     capool,
+			KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		})
+		if err != nil {
+			return fmt.Errorf("TLS validation failed for %q: %s", ep, err)
+		}
+		if isSecure != nil {
+			*isSecure = true
+		}
+		logrus.Debug("Got the following TLS certificates from the endpoint:")
+		for _, c := range certs {
+			logrus.Debugf("> %s   (isCA:%v, issud by %s)", c.Subject.String(), c.IsCA, c.Issuer.String())
+		}
+	}
+	logrus.Debugf("Endpoint %s successfully validated", ep)
+	return nil
+}


### PR DESCRIPTION
This fix adds support for Auto-TLS portworx setup  (gRPC using TLS certs signed by Kubernetes)

Summary of changes:
* config - removed `cacert:<path>` and `cacert-data:<[]byte>`, replaced w/ `certificate-authority-data:<base64>`  (same as KUBECONFIG)
* `pxc config cluster set` - adding connection validation, and `--force` option that skips the validation  (forces config)
* `kubectl pxc` - will add Kubernetes CA and also validate connection and auto-detect SSL/TLS
* Makefile - moved .PHONY at the top, fixing goimports build rules

Signed-off-by: Zoran Rajic <zrajic@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

The Auto-TLS support for Portworx will switch gRPC endpoint to secure TLS/SSL mode, so `pxc / kubectl pxc` will stop working.

As a fix, we added validation of the gRPC endpoints which includes detection (and proper validation) of SSL/TLS gRPC as set up by Portworx.

**Which issue(s) this PR fixes** (optional)
Closes # PWX-28163  (part 2)

Note, this fix also relies on the https://github.com/portworx/px-installer/pull/1556  (part 1 fix)

**Special notes for your reviewer**:

Quick tests:

Added the validation of the endpoint-connection to Portworx
```
$ ./pxc config cluster set --name=default
error connecting to 127.0.0.1:9020: dial tcp 127.0.0.1:9020: connect: connection refused

$ ./pxc config cluster set --name=default --endpoint=10.13.1.33:9020
TLS validation failed for "10.13.1.33:9020": x509: certificate signed by unknown authority

$ kubectl config view --flatten --minify | awk '/certificate-authority-data:/{ print $2 }' | base64 -d > /tmp/ca.crt
$ ./pxc config cluster set --name=default --endpoint=10.13.1.33:9020 --cafile /tmp/ca.crt
Cluster information set
```
* note, we are no longer "blindly" accepting the configuration, but will test it  (including the SSL cert validation)
* there is also a new `--force` option, which will turn off the validation and "force" the blind acceptance of the config


Also added SSL validation (and importing Kubernetes CA) when running in the "plugin mode" as `kubectl pxc` :
```
$ kubectl pxc --pxc.v 3 cluster describe
INFO[0000] pxc version: (DEV)                           
INFO[0000] CurrentContext = kubernetes-admin@kubernetes 
INFO[0000] Kubectl plugin mode detected                 
INFO[0000] Port forwarder using kubeconfig              
DEBU[0000] port-forward: CurrentCluster: config.Cluster{Name:"kubernetes", CACertData:"", Endpoint:"", Secure:false, TunnelServiceNamespace:"kube-system", TunnelServiceName:"portworx-api", TunnelServicePort:"9020"} 
DEBU[0000] port-forward: running "kubectl -n kube-system port-forward svc/portworx-api :9020" 
DEBU[0000] port-forward: started                        
INFO[0003] Connected to localhost:35747                 
DEBU[0003] Read 40 bytes                                
DEBU[0003] Output: Forwarding from 127.0.0.1:35747 -> 9020 
INFO[0003] Connecting to Portworx at endpoint localhost:35747 
INFO[0003] CurrentContext = kubernetes-admin@kubernetes 
DEBU[0003] Appending custom CA certificate              
DEBU[0003] Connecting to localhost:35747                
DEBU[0004] Checking TLS certificate                     
DEBU[0004] Got the following TLS certificates from the endpoint: 
DEBU[0004] > CN=system:node:foo4,O=system:nodes   (isCA:false, issud by CN=kubernetes) 
DEBU[0004] Endpoint localhost:35747 successfully validated 
DEBU[0004] Setting up TLS for grpc connection to localhost:35747 
INFO[0005] Connected to localhost:35747                 
INFO[0006] Information about the node which was used: SDK Version[0.152.0] MoreInfo[build:042dcda5b4b8501771bf6f81f0b9b623a4108d23] 
Name: px-cluster-bedd70f2-7fd7-435f-9aa5-0a7bb639f9b7
UUID: 0cd28d42-7da1-4fcf-a617-59b152b44c00
Status: Ready

Nodes:
Hostname  Version          Used     Capacity  Status  Kernel Version               OS
--------  -------          ----     --------  ------  --------------               --
foo2      3.0.0.0-042dcda  3.0 GiB  20 GiB    Ready   4.15.0-200-generic           Ubuntu 18.04.6 LTS
foo5      3.0.0.0-042dcda  3.0 GiB  20 GiB    Ready   4.18.0-240.1.1.el8_3.x86_64  CentOS Linux 8
foo4      3.0.0.0-042dcda  3.0 GiB  20 GiB    Ready   4.18.0-240.1.1.el8_3.x86_64  CentOS Linux 8
foo3      3.0.0.0-042dcda  3.0 GiB  20 GiB    Ready   5.4.0-135-generic            Ubuntu 20.04.5 LTS
DEBU[0008] Port forwarding stopped                      
DEBU[0008] Closing Ctrl-C capturing function            
```
* note, the messages from `Checking TLS certificate` till `Setting up TLS for grpc` are new messages (new code) added by this PR
